### PR TITLE
Prevent enemies from flipping off player

### DIFF
--- a/Scenes/Enemies/ConeSniper.cs
+++ b/Scenes/Enemies/ConeSniper.cs
@@ -221,7 +221,10 @@ public class FireAtWill : IAi
 
     public XDirection NextXDirection(XDirection current) =>
         _state switch {
-            ShootingState.READYING => _self.XDirectionTo(_target),
+            ShootingState.READYING => 
+                _self.GlobalPosition.DistanceTo(_target.GlobalPosition) < IAi.DISTANCE_PLAYER_MIGHT_BE_ON_TOP
+                 ? current
+                 : _self.XDirectionTo(_target),
             _ => current,
         };
     public float FootSpeed() => 0;

--- a/Scenes/Enemies/ConeWalker.cs
+++ b/Scenes/Enemies/ConeWalker.cs
@@ -120,9 +120,11 @@ public class Chase : IAi
         _self = self;
         _target = target;
     }
-    
+
     public XDirection NextXDirection(XDirection current) =>
-        _self.XDirectionTo(_target);
+        _self.GlobalPosition.DistanceTo(_target.GlobalPosition) < IAi.DISTANCE_PLAYER_MIGHT_BE_ON_TOP
+         ? current
+         : _self.XDirectionTo(_target);
 
     public float FootSpeed() => 6000;
 }

--- a/Scenes/Enemies/RandomFlyer.cs
+++ b/Scenes/Enemies/RandomFlyer.cs
@@ -136,7 +136,8 @@ public partial class RandomFlyer : Node2D, IHittable
             }
             case State.PURSUING: {
                 var movement = Vector2s.FromPolar(50f * (float)delta, _body.GetAngleToNode(_target));
-                _body.XDirMan.Direction = movement.XDirectionFromOrigin();
+                if (_target.GlobalPosition.DistanceTo(_body.GlobalPosition) > IAi.DISTANCE_PLAYER_MIGHT_BE_ON_TOP)
+                    _body.XDirMan.Direction = movement.XDirectionFromOrigin();
                 _body.MoveAndCollide(movement);
 
                 if (_body.GlobalPosition.DistanceTo(_target.GlobalPosition) < 75 && _attackCooldownElapsed > ATTACK_COOLDOWN_TIME)
@@ -159,7 +160,8 @@ public partial class RandomFlyer : Node2D, IHittable
             case State.READYING_ATTACK: {
                 _readyingAttackTimeElapsed += delta;
                 var movement = Vector2s.FromPolar(-5f * (float)delta, _body.GetAngleToNode(_target));
-                _body.XDirMan.Direction = movement.XDirectionFromOrigin();
+                if (_target.GlobalPosition.DistanceTo(_body.GlobalPosition) > IAi.DISTANCE_PLAYER_MIGHT_BE_ON_TOP)
+                    _body.XDirMan.Direction = movement.XDirectionFromOrigin();
                 _body.MoveAndCollide(movement);
 
                 if (_readyingAttackTimeElapsed >= READYING_ATTACK_TIME)
@@ -184,7 +186,8 @@ public partial class RandomFlyer : Node2D, IHittable
             case State.ATTACKING: {
                 _attackTimeElapsed += delta; 
                 var movement = Vector2s.FromPolar(150f * (float)delta, _attackAngle.Radians);
-                _body.XDirMan.Direction = movement.XDirectionFromOrigin();
+                if (_target.GlobalPosition.DistanceTo(_body.GlobalPosition) > IAi.DISTANCE_PLAYER_MIGHT_BE_ON_TOP)
+                    _body.XDirMan.Direction = movement.XDirectionFromOrigin();
                 var collision = _body.MoveAndCollide(movement);
                 
                 if (collision is not null || _attackTimeElapsed > ATTACK_TIME)

--- a/Scenes/Enemies/Utilities/Ai.cs
+++ b/Scenes/Enemies/Utilities/Ai.cs
@@ -4,6 +4,8 @@ using System.Linq;
 
 public interface IAi
 {
+    public const float DISTANCE_PLAYER_MIGHT_BE_ON_TOP = 30f;
+
     void _PhysicsProcess(double delta) {}
     XDirection NextXDirection(XDirection current) => current;
 


### PR DESCRIPTION
Workaround to make sure enemies don't do instantaneous horizontal flips while the player might be standing on them. Pretty hard to tell that's what it's doing in the cases I tried (good thing)! But it's hacked in in a way where it doesn't account for enemy size. 